### PR TITLE
NSFileHandle: implement readDataToEndOfFile

### DIFF
--- a/src/frameworks/foundation/ns_file_handle.rs
+++ b/src/frameworks/foundation/ns_file_handle.rs
@@ -106,6 +106,15 @@ pub const CLASSES: ClassExports = objc_classes! {
     }
 }
 
+- (id)readDataToEndOfFile { // NSData*
+    let offset: i64 = msg![env; this offsetInFile];
+    let eof: i64 = msg![env; this seekToEndOfFile];
+    let _: () = msg![env; this seekToFileOffset:offset];
+    let length: NSUInteger = (eof - offset).try_into().unwrap();
+
+    msg![env; this readDataOfLength:length]
+}
+
 - (())writeData:(id)data { // NSData *
     let fd = env.objc.borrow::<NSFileHandleHostObject>(this).fd;
     let bytes: ConstVoidPtr = msg![env; data bytes];


### PR DESCRIPTION
This allows Critter Crunch (1.0, iOS 2.0) to boot.

Change-Id: I74a591d4384a7e214c6b2866df758a060c9435bb